### PR TITLE
Fix FS arguments.

### DIFF
--- a/.functions
+++ b/.functions
@@ -64,7 +64,7 @@ function fs() {
 	if [[ -n "$@" ]]; then
 		du $arg -- "$@";
 	else
-		du $arg .[^.]* *;
+		du $arg .[^.]* ./*;
 	fi;
 }
 


### PR DESCRIPTION
This fix will accept file names with a dash without interrupting them as an argument. Found by running shellcheck.